### PR TITLE
Fix type error on startup

### DIFF
--- a/ffmpeg-split.py
+++ b/ffmpeg-split.py
@@ -139,7 +139,7 @@ def main():
                         action = "store"
                         )
     parser.add_option("-s", "--split-size",
-                        dest = "split_size",
+                        dest = "split_length",
                         help = "Split or chunk size in seconds, for example 10",
                         type = "int",
                         action = "store"
@@ -168,7 +168,7 @@ def main():
 
     if options.filename and options.manifest:
         split_by_manifest(**(options.__dict__))
-    elif options.filename and options.split_size:
+    elif options.filename and options.split_length:
         split_by_seconds(**(options.__dict__))
     else:
         parser.print_help()


### PR DESCRIPTION
This patch solves following error:
```
Traceback (most recent call last):
  File "/home/shahin/bin/ffmpeg-split.py", line 178, in <module>
    main()
  File "/home/shahin/bin/ffmpeg-split.py", line 172, in main
    split_by_seconds(**(options.__dict__))
TypeError: split_by_seconds() takes at least 2 arguments (3 given)
```