### PR TITLE
Ported to Python 3, fixed issue with ffmpeg command

### DIFF
--- a/ffmpeg-split-py2.py
+++ b/ffmpeg-split-py2.py
@@ -15,7 +15,6 @@ re_length = re.compile(length_regexp)
 def split_by_manifest(filename, manifest, vcodec="copy", acodec="copy",
                       extra="", **kwargs):
     """ Split video into segments based on the given manifest file.
-
     Arguments:
         filename (str)      - Location of the video.
         manifest (str)      - Location of the manifest file.
@@ -26,7 +25,7 @@ def split_by_manifest(filename, manifest, vcodec="copy", acodec="copy",
         extra (str)         - Extra options for ffmpeg.
     """
     if not os.path.exists(manifest):
-        print("File does not exist: %s" % manifest)
+        print "File does not exist: %s" % manifest
         raise SystemExit
 
     with open(manifest) as manifest_file:
@@ -36,7 +35,7 @@ def split_by_manifest(filename, manifest, vcodec="copy", acodec="copy",
         elif manifest_type == "csv":
             config = csv.DictReader(manifest_file)
         else:
-            print("Format not supported. File must be a csv or json file")
+            print "Format not supported. File must be a csv or json file"
             raise SystemExit
 
         split_cmd = "ffmpeg -i \"%s\" -vcodec %s -acodec %s -y %s" % (filename,
@@ -62,24 +61,24 @@ def split_by_manifest(filename, manifest, vcodec="copy", acodec="copy",
 
                 split_str += " -ss " + str(split_start) + " -t " + \
                     str(split_length) + \
-                    " \"" + filebase + "." + fileext + \
+                    " \""+ filebase + "." + fileext + \
                     "\""
-                print("########################################################")
-                print("About to run: " + split_cmd + split_str)
-                print("########################################################")
-                output = subprocess.Popen(split_cmd + split_str,
+                print "########################################################"
+                print "About to run: "+split_cmd+split_str
+                print "########################################################"
+                output = subprocess.Popen(split_cmd+split_str,
                                           shell = True, stdout =
                                           subprocess.PIPE).stdout.read()
             except KeyError as e:
-                print("############# Incorrect format ##############")
+                print "############# Incorrect format ##############"
                 if manifest_type == "json":
-                    print("The format of each json array should be:")
-                    print("{start_time: <int>, length: <int>, rename_to: <string>}")
+                    print "The format of each json array should be:"
+                    print "{start_time: <int>, length: <int>, rename_to: <string>}"
                 elif manifest_type == "csv":
-                    print("start_time,length,rename_to should be the first line ")
-                    print("in the csv file.")
-                print("#############################################")
-                print(e)
+                    print "start_time,length,rename_to should be the first line "
+                    print "in the csv file."
+                print "#############################################"
+                print e
                 raise SystemExit
 
 
@@ -87,26 +86,26 @@ def split_by_manifest(filename, manifest, vcodec="copy", acodec="copy",
 def split_by_seconds(filename, split_length, vcodec="copy", acodec="copy",
                      extra="", **kwargs):
     if split_length and split_length <= 0:
-        print("Split length can't be 0")
+        print "Split length can't be 0"
         raise SystemExit
 
     output = subprocess.Popen("ffmpeg -i \""+filename+"\" 2>&1 | grep 'Duration'",
                             shell = True,
                             stdout = subprocess.PIPE
                             ).stdout.read()
-    print(output)
+    print output
     matches = re_length.search(output)
     if matches:
         video_length = int(matches.group(1)) * 3600 + \
                         int(matches.group(2)) * 60 + \
                         int(matches.group(3))
-        print("Video length in seconds: " + str(video_length))
+        print "Video length in seconds: "+str(video_length)
     else:
-        print("Can't determine video length.")
+        print "Can't determine video length."
         raise SystemExit
     split_count = int(math.ceil(video_length/float(split_length)))
     if(split_count == 1):
-        print("Video length is less then the target split length.")
+        print "Video length is less then the target split length."
         raise SystemExit
 
     split_cmd = "ffmpeg -i \"%s\" -vcodec %s -acodec %s %s" % (filename, vcodec,
@@ -123,11 +122,11 @@ def split_by_seconds(filename, split_length, vcodec="copy", acodec="copy",
         else:
             split_start = split_length * n
 
-        split_str += " -ss " + str(split_start) + " -t " + str(split_length) + \
-                    " \"" + filebase + "-" + str(n) + "." + fileext + \
+        split_str += " -ss "+str(split_start)+" -t "+str(split_length) + \
+                    " \""+filebase + "-" + str(n) + "." + fileext + \
                     "\""
-        print("About to run: " + split_cmd + split_str)
-        output = subprocess.Popen(split_cmd + split_str, shell = True, stdout =
+        print "About to run: "+split_cmd+split_str
+        output = subprocess.Popen(split_cmd+split_str, shell = True, stdout =
                                subprocess.PIPE).stdout.read()
 
 
@@ -184,4 +183,4 @@ def main():
         raise SystemExit
 
 if __name__ == '__main__':
-    main()
+	main()


### PR DESCRIPTION
**Porting to Python 3**
- Porting to Python 3 involved just modifying the print statements (also added some spacing here and there, nothing drastic).
- Left Python 2 version as `ffmpeg-split-py2.py` in case people want to execute it under Py2 interpreter.

**The Bigger Issue**

When executing the ffmpeg command, passing in arguments [to ffmpeg] as they were (ex. they have spaces so when passed in they retain the spaces) was wrapped in single quotes. It may be possible that ffmpeg on Windows (win10 specifically) handles arguments differently than other systems and only accepts arguments as they were explicitly passed in when wrapped in double quotes.

That sounds a bit complicated, so here's an example (doesn't matter which Python version we're using here)
```
python ffmpeg-split.py -f "my video.mp4" -m manifest.json
```
would result in some execution in the form of
```
ffmpeg -i 'my video.mp4' [other args]
```
This is invalid because it doesn't treat `'my video.mp4'` as one single argument, but instead as two individual arguments (`my` and `video.mp4`). To resolve this, you'd wrap it in double quotes so the ffmpeg execution would be
```
ffmpeg -i "my video.mp4" [other args]
```
which properly treats our video as one, single argument instead of two separated by the space. This issue was also found when specifying the output file, which is also accommodated for.